### PR TITLE
feat: add `--repair` and `--no-auto-login` CLI options

### DIFF
--- a/.changeset/add-repair-and-no-auto-login.md
+++ b/.changeset/add-repair-and-no-auto-login.md
@@ -1,0 +1,20 @@
+---
+"gh-setup-git-identity": minor
+---
+
+Add `--repair` and `--no-auto-login` CLI options
+
+## New Features
+
+### `--repair` option
+Repair git identity configuration without triggering the login flow. This is useful when:
+- Git operations fail with "empty ident name not allowed" error
+- The `user.name` or `user.email` was accidentally cleared or corrupted
+- You want to reconfigure git identity without going through login again
+
+The `--repair` option requires existing GitHub CLI authentication.
+
+### `--no-auto-login` option
+Disable automatic login if not authenticated. Instead of starting the interactive login process, the tool will exit with an error and show manual authentication instructions.
+
+This is useful in scripts or automated environments where you want to fail fast rather than wait for an interactive login prompt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/gh-setup-git-identity/issues/28
-Your prepared branch: issue-28-ad1a61cb82d8
-Your prepared working directory: /tmp/gh-issue-solver-1768488016332
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/gh-setup-git-identity/issues/28
+Your prepared branch: issue-28-ad1a61cb82d8
+Your prepared working directory: /tmp/gh-issue-solver-1768488016332
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Git Identity Options:
   --local, -l          Set git config locally (in current repository)
   --dry-run, --dry     Dry run - show what would be done without making changes
   --verify             Verify current git identity configuration
+  --repair             Repair git identity without triggering login (requires existing auth)
+  --no-auto-login      Disable automatic login if not authenticated
   --verbose, -v        Enable verbose output
 
 GitHub Authentication Options:
@@ -209,6 +211,33 @@ gh auth status
 git config --local user.name
 git config --local user.email
 ```
+
+### Repairing Configuration
+
+If your git identity configuration becomes corrupted or misconfigured (e.g., empty `user.name` or `user.email`), you can use the `--repair` option to fix it without triggering a new login:
+
+```bash
+# Repair git identity using existing authentication
+gh-setup-git-identity --repair
+```
+
+This is useful when:
+- Git operations fail with "empty ident name not allowed" error
+- The `user.name` or `user.email` was accidentally cleared or corrupted
+- You want to reconfigure git identity without going through the login flow again
+
+The `--repair` option requires that you're already authenticated with GitHub CLI. If not authenticated, it will show helpful instructions for manual authentication.
+
+### Disabling Auto-Login
+
+By default, if you're not authenticated, the tool will automatically start the GitHub CLI login process. You can disable this behavior:
+
+```bash
+# Fail immediately if not authenticated (don't auto-login)
+gh-setup-git-identity --no-auto-login
+```
+
+This is useful in scripts or automated environments where you want to fail fast rather than wait for an interactive login prompt.
 
 ## Library Usage
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -176,3 +176,20 @@ test('default export contains all functions', async () => {
   assert.ok(typeof defaultExport.setupGitIdentity === 'function');
   assert.ok(typeof defaultExport.verifyGitIdentity === 'function');
 });
+
+// Test: CLI --repair and --no-auto-login options are present
+// Note: Full CLI integration tests would require mocking the subprocess
+test('CLI module has --repair and --no-auto-login options', async () => {
+  // This test verifies the CLI module syntax is correct and options exist
+  const fs = await import('node:fs');
+  const cliContent = fs.readFileSync(new URL('../src/cli.js', import.meta.url), 'utf-8');
+
+  // Verify the new options are defined in the CLI
+  assert.ok(cliContent.includes("'repair'"), 'CLI should have --repair option');
+  assert.ok(cliContent.includes("'no-auto-login'"), 'CLI should have --no-auto-login option');
+
+  // Verify the repair/no-auto-login logic is implemented
+  assert.ok(cliContent.includes('skipAutoLogin'), 'CLI should have skipAutoLogin logic');
+  assert.ok(cliContent.includes('config.repair'), 'CLI should check config.repair');
+  assert.ok(cliContent.includes('config.noAutoLogin'), 'CLI should check config.noAutoLogin');
+});


### PR DESCRIPTION
## Summary

This PR adds two new CLI options to handle repair scenarios and control auto-login behavior, as requested in #28.

**Fixes #28**

## New Options

### `--repair`
Repair git identity configuration without triggering the login flow. This option:
- Requires existing GitHub CLI authentication
- Skips the automatic login process
- Only reconfigures `user.name` and `user.email` using the authenticated GitHub user

**Use case**: When git operations fail with "empty ident name not allowed" error, or when git identity configuration becomes corrupted.

```bash
gh-setup-git-identity --repair
```

### `--no-auto-login`
Disable automatic login if not authenticated. Instead of starting the interactive login process, the tool will exit with an error and show manual authentication instructions.

**Use case**: Scripts or automated environments where you want to fail fast rather than wait for an interactive login prompt.

```bash
gh-setup-git-identity --no-auto-login
```

## Changes

- **CLI options** in `src/cli.js`:
  - Added `--repair` option
  - Added `--no-auto-login` option
  - Implemented `skipAutoLogin` logic to handle both options
  - Show helpful error messages when not authenticated

- **Documentation** in `README.md`:
  - Added options to CLI reference
  - Added "Repairing Configuration" section
  - Added "Disabling Auto-Login" section
  - Added usage examples

- **Tests** in `test/index.test.js`:
  - Added test to verify CLI options exist

- **Changeset** for version bump:
  - Added `.changeset/add-repair-and-no-auto-login.md` for minor version

## Test Plan

- [x] All existing tests pass (`bun test` - 14 tests)
- [x] Lint passes (`bun run lint`)
- [x] CLI help shows new options (`--help`)
- [x] Changeset added for minor version bump

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)